### PR TITLE
feat(Root): always refetch user data on '/' mount

### DIFF
--- a/src/routes/Root.tsx
+++ b/src/routes/Root.tsx
@@ -20,7 +20,8 @@ function Root(): JSX.Element {
       await fetchPlayer({
         accessToken: accessToken as string,
         name: user?.name as string,
-      })
+      }),
+    { refetchOnMount: "always" }
   );
 
   const { setUser, getUser } = useUserStore();


### PR DESCRIPTION
This should solve the problem with the stale user data as while hitting `/` route, it was not always considered data as stale, but now it should, so that on each visit `/` - a new chunk of user data will be fetched.