### PR TITLE
refactor/tournament-to-location

### DIFF
--- a/src/api/game/post/types.ts
+++ b/src/api/game/post/types.ts
@@ -1,5 +1,5 @@
 import { type IPlayerRef, type IPlayerScore } from "../types";
-import { type ITournamentRef } from "./../types";
+import { type ILocationRef } from "./../types";
 
 interface IPlayerRefId extends Omit<IPlayerRef, "name" | "rating"> {}
 
@@ -8,10 +8,10 @@ interface IPlayerScoreWOutAlternation
   playerRef: IPlayerRefId;
 }
 
-interface ITournamentRefId extends Omit<ITournamentRef, "name"> {}
+interface ILocationRefId extends Omit<ILocationRef, "name"> {}
 
 export interface IPostGameBody {
   playerScoreA: IPlayerScoreWOutAlternation;
   playerScoreB: IPlayerScoreWOutAlternation;
-  tournamentRef: ITournamentRefId;
+  locationRef: ILocationRefId;
 }

--- a/src/api/game/types.ts
+++ b/src/api/game/types.ts
@@ -2,11 +2,11 @@ export interface IGame {
   id: string;
   playerScoreA: IPlayerScore;
   playerScoreB: IPlayerScore;
-  tournamentRef: ITournamentRef;
+  locationRef: ILocationRef;
   winnerId: string;
   playedWhen: string;
 }
-export interface ITournamentRef {
+export interface ILocationRef {
   id: string;
   name: string;
 }

--- a/src/api/location/get/queries.ts
+++ b/src/api/location/get/queries.ts
@@ -1,0 +1,7 @@
+import { getRequest } from "../../request";
+import { type ILocationList } from "./types";
+import { locationList } from "./urls";
+
+export async function fetchLocationList(): Promise<ILocationList[]> {
+  return await getRequest({ url: locationList() });
+}

--- a/src/api/location/get/types.ts
+++ b/src/api/location/get/types.ts
@@ -1,0 +1,4 @@
+export interface ILocationList {
+  id: string;
+  name: string;
+}

--- a/src/api/location/get/urls.ts
+++ b/src/api/location/get/urls.ts
@@ -1,0 +1,3 @@
+import { baseURL } from "../../urls";
+
+export const locationList = (): string => `${baseURL}/location/list`;

--- a/src/api/player/get/queries.ts
+++ b/src/api/player/get/queries.ts
@@ -10,11 +10,11 @@ import { playerFind, playerList } from "./urls";
 export async function fetchPlayerList({
   page,
   size,
-  tournamentId,
+  locationId,
   minGamesPlayed,
 }: IPlayerListParams): Promise<IPlayerList> {
   return await getRequest({
-    url: playerList({ page, size, tournamentId, minGamesPlayed }),
+    url: playerList({ page, size, locationId, minGamesPlayed }),
   });
 }
 

--- a/src/api/player/get/types.ts
+++ b/src/api/player/get/types.ts
@@ -4,7 +4,7 @@ export interface IPlayerListParams {
   page: number;
   size: number;
   minGamesPlayed?: number;
-  tournamentId?: string;
+  locationId?: string;
 }
 
 export interface IPlayerFindParams {
@@ -16,7 +16,7 @@ export interface IPlayer {
   name: string;
   email: string;
   profileImage: string;
-  tournamentRef: {
+  locationRef: {
     id: string;
     name: string;
   };

--- a/src/api/player/get/urls.ts
+++ b/src/api/player/get/urls.ts
@@ -4,17 +4,17 @@ import { type IPlayerFindParams, type IPlayerListParams } from "./types";
 export const playerList = ({
   page,
   size,
-  tournamentId,
+  locationId,
   minGamesPlayed,
 }: IPlayerListParams): string => {
-  if (minGamesPlayed != null && tournamentId != null) {
-    return `${baseURL}/player/list?page=${page}&size=${size}&tournamentId=${tournamentId}&minGamesPlayed=${minGamesPlayed}`;
+  if (minGamesPlayed != null && locationId != null) {
+    return `${baseURL}/player/list?page=${page}&size=${size}&locationId=${locationId}&minGamesPlayed=${minGamesPlayed}`;
   }
   if (minGamesPlayed != null) {
     return `${baseURL}/player/list?page=${page}&size=${size}&minGamesPlayed=${minGamesPlayed}`;
   }
-  if (tournamentId != null) {
-    return `${baseURL}/player/list?page=${page}&size=${size}&tournamentId=${tournamentId}`;
+  if (locationId != null) {
+    return `${baseURL}/player/list?page=${page}&size=${size}&locationId=${locationId}`;
   }
   return `${baseURL}/player/list?page=${page}&size=${size}`;
 };

--- a/src/api/player/post/types.ts
+++ b/src/api/player/post/types.ts
@@ -2,7 +2,7 @@ export interface IPostPlayerBody {
   name: string;
   email: string;
   profileImage: string;
-  tournamentRef: {
+  locationRef: {
     id: string;
   };
 }

--- a/src/api/tournament/get/queries.ts
+++ b/src/api/tournament/get/queries.ts
@@ -1,7 +1,0 @@
-import { getRequest } from "../../request";
-import { type ITournamentList } from "./types";
-import { tournamentList } from "./urls";
-
-export async function fetchTournamentList(): Promise<ITournamentList[]> {
-  return await getRequest({ url: tournamentList() });
-}

--- a/src/api/tournament/get/types.ts
+++ b/src/api/tournament/get/types.ts
@@ -1,4 +1,0 @@
-export interface ITournamentList {
-  id: string;
-  name: string;
-}

--- a/src/api/tournament/get/urls.ts
+++ b/src/api/tournament/get/urls.ts
@@ -1,3 +1,0 @@
-import { baseURL } from "../../urls";
-
-export const tournamentList = (): string => `${baseURL}/tournament/list`;

--- a/src/components/ChooseOfficeDropdown.tsx
+++ b/src/components/ChooseOfficeDropdown.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 
-import { fetchTournamentList } from "../api/tournament/get/queries";
+import { fetchLocationList } from "../api/location/get/queries";
 import { useOfficeStore, useUserStore } from "../store";
 import { LoadingSpinner } from "./LoadingSpinner";
 
@@ -11,33 +11,27 @@ export const ChooseOfficeDropdown = (): JSX.Element => {
 
   const { setOfficeId } = useOfficeStore();
 
-  const { data: tournamentList, isLoading: isTournamentListLoading } = useQuery(
-    ["tournamentList", fetchTournamentList],
-    async () => await fetchTournamentList()
+  const { data: locationList, isLoading: isLocationListLoading } = useQuery(
+    ["locationList", fetchLocationList],
+    async () => await fetchLocationList()
   );
 
-  const sortedTournamentList = useMemo(() => {
-    if (tournamentList != null) {
+  const sortedLocationList = useMemo(() => {
+    if (locationList != null) {
       return [
-        ...tournamentList?.filter(
-          (x) => x.id === currentUser?.tournamentRef.id
-        ),
-        ...tournamentList?.filter(
-          (x) => x.id !== currentUser?.tournamentRef.id
-        ),
+        ...locationList?.filter((x) => x.id === currentUser?.locationRef.id),
+        ...locationList?.filter((x) => x.id !== currentUser?.locationRef.id),
       ];
     } else {
-      return tournamentList;
+      return locationList;
     }
-  }, [tournamentList]);
+  }, [locationList]);
 
-  const _onTournamentChange = (
-    e: React.ChangeEvent<HTMLSelectElement>
-  ): void => {
+  const _onLocationChange = (e: React.ChangeEvent<HTMLSelectElement>): void => {
     setOfficeId(e.target.value);
   };
 
-  return isTournamentListLoading ? (
+  return isLocationListLoading ? (
     <LoadingSpinner />
   ) : (
     <>
@@ -45,12 +39,12 @@ export const ChooseOfficeDropdown = (): JSX.Element => {
         <span className="indicator-item badge badge-accent">Office</span>
         <select
           className="select select-info w-full max-w-xs"
-          onChange={_onTournamentChange}
+          onChange={_onLocationChange}
         >
-          {sortedTournamentList?.map((tournament) => {
+          {sortedLocationList?.map((location) => {
             return (
-              <option key={tournament.id} value={tournament.id}>
-                {tournament.name}
+              <option key={location.id} value={location.id}>
+                {location.name}
               </option>
             );
           })}

--- a/src/components/tables/RatingTable.tsx
+++ b/src/components/tables/RatingTable.tsx
@@ -75,7 +75,7 @@ export const RatingTable = (): JSX.Element => {
           ? {
               page: pageIndex,
               size: pageSize,
-              tournamentId: officeId,
+              locationId: officeId,
               minGamesPlayed: 1,
             }
           : {

--- a/src/routes/AddGame.tsx
+++ b/src/routes/AddGame.tsx
@@ -120,8 +120,8 @@ export default function AddGame(): JSX.Element {
             score: opponentScore,
           },
           // TODO: this should be a separate selector
-          tournamentRef: {
-            id: currentUser?.tournamentRef.id,
+          locationRef: {
+            id: currentUser?.locationRef.id,
           },
         },
       });

--- a/src/routes/Profile.tsx
+++ b/src/routes/Profile.tsx
@@ -3,9 +3,9 @@ import "../App.css";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 
+import { fetchLocationList } from "../api/location/get/queries";
 import { createPlayer } from "../api/player/post/mutations";
 import { type IPostPlayerBody } from "../api/player/post/types";
-import { fetchTournamentList } from "../api/tournament/get/queries";
 import NavigationBar from "../components/NavigationBar";
 import GamesHistoryTable from "../components/tables/GamesHistoryTable";
 import { WinRate } from "../components/WinRate";
@@ -14,15 +14,15 @@ import { useAuthStore, useUserStore } from "../store";
 import { decodeJWT, type IDecodedIdToken } from "../utils/decodeJWT";
 
 function Profile(): JSX.Element {
-  const [tournamentId, setTournamentId] = useState<string>();
+  const [locationId, setLocationId] = useState<string>();
   const { getAuth } = useAuthStore();
   const auth = getAuth();
   const userFromIdToken = decodeJWT<IDecodedIdToken>(auth?.idToken);
   const { setUser } = useUserStore();
 
-  const { data: tournamentList, isLoading: isTournamentListLoading } = useQuery(
-    ["tournamentList", fetchTournamentList],
-    async () => await fetchTournamentList()
+  const { data: locationList, isLoading: isLocationListLoading } = useQuery(
+    ["locationList", fetchLocationList],
+    async () => await fetchLocationList()
   );
 
   const { mutate: createPlayerMutation } = useMutation({
@@ -35,13 +35,11 @@ function Profile(): JSX.Element {
   const { getUser } = useUserStore();
   const currentUser = getUser();
 
-  const _onTournamentChange = (
-    e: React.ChangeEvent<HTMLSelectElement>
-  ): void => {
-    setTournamentId(e.target.value);
+  const _onLocationChange = (e: React.ChangeEvent<HTMLSelectElement>): void => {
+    setLocationId(e.target.value);
   };
 
-  const _onTournamentSubmit = (body: IPostPlayerBody): void => {
+  const _onLocationSubmit = (body: IPostPlayerBody): void => {
     createPlayerMutation({ body });
   };
 
@@ -57,33 +55,31 @@ function Profile(): JSX.Element {
             <select
               className="select select-info mb-5 mr-5 w-full max-w-xs"
               defaultValue={"DEFAULT"}
-              onChange={_onTournamentChange}
+              onChange={_onLocationChange}
             >
               <option value={"DEFAULT"} disabled>
                 Select office
               </option>
-              {tournamentList?.map((tournament) => {
+              {locationList?.map((location) => {
                 return (
-                  <option key={tournament.id} value={tournament.id}>
-                    {tournament.name}
+                  <option key={location.id} value={location.id}>
+                    {location.name}
                   </option>
                 );
               })}
             </select>
             <button
               className={`btn btn-ghost ${
-                tournamentId != null
-                  ? "btn-outline btn-success"
-                  : "btn-disabled"
-              }  ${isTournamentListLoading ? "loading" : ""}`}
+                locationId != null ? "btn-outline btn-success" : "btn-disabled"
+              }  ${isLocationListLoading ? "loading" : ""}`}
               onClick={() => {
-                if (tournamentId != null && userFromIdToken != null) {
-                  _onTournamentSubmit({
+                if (locationId != null && userFromIdToken != null) {
+                  _onLocationSubmit({
                     name: userFromIdToken.name,
                     email: userFromIdToken.email,
                     profileImage: userFromIdToken.picture,
-                    tournamentRef: {
-                      id: tournamentId,
+                    locationRef: {
+                      id: locationId,
                     },
                   });
                 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -158,24 +158,18 @@ interface IOfficeStateActions {
 }
 
 export const useOfficeStore = create<IOfficeState & IOfficeStateActions>()(
-  persist(
-    (set, get) => ({
-      officeId: undefined,
-      clear: () => {
-        set({
-          officeId: undefined,
-        });
-      },
-      setOfficeId: (officeId) => {
-        set({
-          officeId,
-        });
-      },
-      getOfficeId: () => get().officeId,
-    }),
-    {
-      name: "office-storage", // name of the item in the storage (must be unique)
-      storage: createJSONStorage(() => localStorage),
-    }
-  )
+  (set, get) => ({
+    officeId: undefined,
+    clear: () => {
+      set({
+        officeId: undefined,
+      });
+    },
+    setOfficeId: (officeId) => {
+      set({
+        officeId,
+      });
+    },
+    getOfficeId: () => get().officeId,
+  })
 );


### PR DESCRIPTION
Changes in API: rename `tournament` to `location`.

So, now offices are separated from the tournaments due to the fact that tournaments will likely have different structures.

Also, fixes persistency issues with dropdown fetching the latest office, not one selected by default.